### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "packageManager": "pnpm@9.15.9",
   "description": "vite-plugin-pages based sitemap generator",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jbaubree/vite-plugin-pages-sitemap.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jbaubree/vite-plugin-pages-sitemap/issues"
+  },
+  "homepage": "https://github.com/jbaubree/vite-plugin-pages-sitemap#readme",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Adds standard npm support metadata to the package manifest:

- `repository`
- `bugs`
- `homepage`

No runtime code or dependency changes.

## Checks

- `node -e "const p=require(./package.json); if(p.name!==vite-plugin-pages-sitemap||p.license!==MIT||p.repository?.url!==git+https://github.com/jbaubree/vite-plugin-pages-sitemap.git||p.bugs?.url!==https://github.com/jbaubree/vite-plugin-pages-sitemap/issues||p.homepage!==https://github.com/jbaubree/vite-plugin-pages-sitemap#readme) process.exit(1)"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`