### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "vite-plugin-pages-sitemap",
   "version": "1.7.1",
+  "bugs": {
+    "url": "https://github.com/jbaubree/vite-plugin-pages-sitemap/issues"
+  },
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "description": "vite-plugin-pages based sitemap generator",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.